### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: xain/xain-fl
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/rust_release.yaml
+++ b/.github/workflows/rust_release.yaml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: build docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: xain/xain-fl
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore